### PR TITLE
fix: improve dropdown size for landscape phone

### DIFF
--- a/css/devices/phone.css
+++ b/css/devices/phone.css
@@ -12,3 +12,27 @@
         display:none;
     }
 }
+
+/* Landscape on mobile devices */
+@media (orientation: landscape) and (max-height: 600px) {
+    #dropdown-menu {
+        height: 60vh;
+    }
+    #dropdown-menu #dropdown-options-wrapper {
+        row-gap: 1.5vh;
+    }
+    #dropdown-menu .dropdown-option {
+        padding: 3px;
+        font-size: 1rem;
+        height: 7.2vh;
+    }
+    #dropdown-menu .dropdown-option:hover {
+        font-size: 1.1rem;
+    }
+    #dropdown-menu #dropdown-socials-wrapper {
+        padding-top: 3vh;
+    }
+    #dropdown-menu .socials {
+        font-size: 1.35rem;
+    }
+}


### PR DESCRIPTION
Fix issue where dropdown menu would take up 100% of the height of the screen when using a mobile device in landscape mode. The height now scales with the height of the device.

Closes #25 