### PR TITLE
fix: change dropdown animation for landscape phones

### DIFF
--- a/css/devices/phone.css
+++ b/css/devices/phone.css
@@ -15,6 +15,22 @@
 
 /* Landscape on mobile devices */
 @media (orientation: landscape) and (max-height: 600px) {
+    @keyframes dropdown-appear {
+        from {
+            height: 0;
+        }
+        to {
+            height: 60vh;
+        }
+    }
+    @keyframes dropdown-disappear {
+        from {
+            height: 60vh;
+        }
+        to {
+            height: 0;
+        }
+    }
     #dropdown-menu {
         height: 60vh;
     }


### PR DESCRIPTION
Fix issue where height in `@keyframes` rule was the same for all devices sizes, which didnt correspond to the `60vh` height value on landscape mobile devices.